### PR TITLE
feat: Amazon Bedrock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The code has been verified to work under `Python 3.10.13` with the following dep
 - google.generativeai (0.1.0)
 - immutabledict (3.0.0)
 - openai (0.27.2)
+- boto3 (1.34.162)
 ```
 
 ## Usage

--- a/opro/evaluation/evaluate_instructions.py
+++ b/opro/evaluation/evaluate_instructions.py
@@ -269,6 +269,29 @@ def main(_):
     scorer_llm_dict.update(scorer_finetuned_palm_dict)
     call_scorer_server_func = call_scorer_finetuned_palm_server_func
 
+  elif scorer_llm_name.startswith("bedrock"):
+    # Amazon Bedrock models
+    scorer_bedrock_max_decode_steps = 1024
+    scorer_bedrock_temperature = 0.0
+
+    scorer_bedrock_dict = dict()
+    scorer_bedrock_dict["max_decode_steps"] = scorer_bedrock_max_decode_steps
+    scorer_bedrock_dict["temperature"] = scorer_bedrock_temperature
+    scorer_bedrock_dict["num_decodes"] = 1
+    scorer_bedrock_dict["batch_size"] = 1
+    scorer_bedrock_dict["num_servers"] = 1
+
+    scorer_llm_dict = {
+        "model_type": scorer_llm_name,
+    }
+    scorer_llm_dict.update(scorer_bedrock_dict)
+    call_scorer_server_func = functools.partial(
+        prompt_utils.call_amazon_bedrock_func,
+        model=scorer_llm_name.split("/")[-1],
+        max_decode_steps=scorer_bedrock_max_decode_steps,
+        temperature=scorer_bedrock_temperature,
+    )
+
   else:
     # GPT models
     assert scorer_llm_name.lower() in {"gpt-3.5-turbo", "gpt-4"}

--- a/opro/optimization/optimize_linear_regression.py
+++ b/opro/optimization/optimize_linear_regression.py
@@ -75,13 +75,15 @@ def main(_):
       "text-bison",
       "gpt-3.5-turbo",
       "gpt-4",
-  }
+  } or optimizer_llm_name.startswith("bedrock")
   openai_api_key = _OPENAI_API_KEY.value
   palm_api_key = _PALM_API_KEY.value
 
   if optimizer_llm_name in {"gpt-3.5-turbo", "gpt-4"}:
     assert openai_api_key, "The OpenAI API key must be provided."
     openai.api_key = openai_api_key
+  elif optimizer_llm_name.startswith("bedrock"):
+    pass
   else:
     assert optimizer_llm_name == "text-bison"
     assert (

--- a/opro/optimization/optimize_linear_regression.py
+++ b/opro/optimization/optimize_linear_regression.py
@@ -139,6 +139,21 @@ def main(_):
     optimizer_llm_dict.update(optimizer_finetuned_palm_dict)
     call_optimizer_server_func = call_optimizer_finetuned_palm_server_func
 
+  elif optimizer_llm_name.startswith("bedrock"):
+    optimizer_bedrock_max_decode_steps = 1024
+    optimizer_bedrock_temperature = 1.0
+
+    optimizer_llm_dict = dict()
+    optimizer_llm_dict["max_decode_steps"] = optimizer_bedrock_max_decode_steps
+    optimizer_llm_dict["temperature"] = optimizer_bedrock_temperature
+    optimizer_llm_dict["batch_size"] = 1
+    call_optimizer_server_func = functools.partial(
+        prompt_utils.call_amazon_bedrock_func,
+        model=optimizer_llm_name.split("/")[-1],
+        max_decode_steps=optimizer_bedrock_max_decode_steps,
+        temperature=optimizer_bedrock_temperature,
+    )
+
   else:
     assert optimizer_llm_name in {"gpt-3.5-turbo", "gpt-4"}
     optimizer_gpt_max_decode_steps = 1024

--- a/opro/optimization/optimize_tsp.py
+++ b/opro/optimization/optimize_tsp.py
@@ -142,6 +142,21 @@ def main(_):
     optimizer_llm_dict.update(optimizer_finetuned_palm_dict)
     call_optimizer_server_func = call_optimizer_finetuned_palm_server_func
 
+  elif optimizer_llm_name.startswith("bedrock"):
+    optimizer_bedrock_max_decode_steps = 1024
+    optimizer_bedrock_temperature = 1.0
+
+    optimizer_llm_dict = dict()
+    optimizer_llm_dict["max_decode_steps"] = optimizer_bedrock_max_decode_steps
+    optimizer_llm_dict["temperature"] = optimizer_bedrock_temperature
+    optimizer_llm_dict["batch_size"] = 1
+    call_optimizer_server_func = functools.partial(
+        prompt_utils.call_amazon_bedrock_func,
+        model=optimizer_llm_name.split("/")[-1],
+        max_decode_steps=optimizer_bedrock_max_decode_steps,
+        temperature=optimizer_bedrock_temperature,
+    )
+
   else:
     assert optimizer_llm_name in {"gpt-3.5-turbo", "gpt-4"}
     optimizer_gpt_max_decode_steps = 1024

--- a/opro/optimization/optimize_tsp.py
+++ b/opro/optimization/optimize_tsp.py
@@ -78,13 +78,15 @@ def main(_):
       "text-bison",
       "gpt-3.5-turbo",
       "gpt-4",
-  }
+  } or optimizer_llm_name.startswith("bedrock")
   openai_api_key = _OPENAI_API_KEY.value
   palm_api_key = _PALM_API_KEY.value
 
   if optimizer_llm_name in {"gpt-3.5-turbo", "gpt-4"}:
     assert openai_api_key, "The OpenAI API key must be provided."
     openai.api_key = openai_api_key
+  elif optimizer_llm_name.startswith("bedrock"):
+    pass
   else:
     assert optimizer_llm_name == "text-bison"
     assert (


### PR DESCRIPTION
This PR adds support for [Amazon Bedrock](https://aws.amazon.com/bedrock/) models (scorer + optimizer).

**Example:**

```bash
python optimize_instructions.py --optimizer="bedrock/mistral.mixtral-8x7b-instruct-v0:1" \
                                --scorer="bedrock/anthropic.claude-3-sonnet-20240229-v1:0" \
                                --instruction_pos="Q_begin" \
                                --dataset="gsm8k" \
                                --task="train"
```